### PR TITLE
chore: Fix knigkit command connot be found after installing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Syntax is close to [chisel3](https://github.com/chipsalliance/chisel3), without 
 ## Quick Install
 
 ```shell
-$ pip3 install knitkit
+$ sudo pip3 install knitkit
 $ knitkit create hello_knitkit
 $ cd hello_knitkit
 $ make verilog
@@ -107,7 +107,7 @@ $ touch build.sc
 
 ```
 import mill._, scalalib._
-  
+
 object hello extends ScalaModule {
   def scalaVersion = "2.13.6"
   def millSourcePath = super.millSourcePath / ammonite.ops.up
@@ -140,7 +140,7 @@ $ mill hello.run builds
 
 ```scala
 import knitkit._
-  
+
 class Mux2 extends RawModule {
   override def desiredName = "Mux2"
   val sel = IO(Input(UInt(1.W)))


### PR DESCRIPTION
Dear Wei Wei:

       我发现使用 pip3 安装 knitkit, 安装完后是在 /home/user/local下，此时找不到 knitkit 命令，后面的步骤就走不下去了，加一个 sudo 就能解决这个问题 。 ^_^

Good luck!
Your Kun Kun

